### PR TITLE
update README for required ordered of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This program is a simple terminal interface for UNIX-domain sockets.
 I use this regularly with VMware/Virtualbox VMs with serial ports
 (primarily for serial console/kernel debugging).
 
-To use: ```cc -O cus.c -o cus && ./cus [-l logfile] path-to-socket```
+To use: ```cc -O cus.c -o cus && ./cus path-to-socket [-l logfile]```


### PR DESCRIPTION
I forgot to update the README to indicate the required order of command line arguments.